### PR TITLE
Implement aging and collapse logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ make
 ```
 
 O programa gera um mapa 20x10 com algumas células contendo símbolos.
-Se uma célula com símbolo tiver o clima de esperança, uma nova
-civilização aparece. As civilizações envelhecem e colapsam após certo
-período.
+Durante vários turnos, se uma célula tiver o clima "Luto" e o símbolo
+"Nome Apagado", nasce uma nova civilização. Cada civilização envelhece a
+cada turno e colapsa após atingir cinco turnos de idade.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,9 +1,18 @@
 #include "map.hpp"
 
-int main() {
+void runSimulation(int turns) {
     Map worldMap;
     std::cout << "Mapa emocional de UltraWorld:\n";
     worldMap.printMap();
-    worldMap.detectCivilizationBirths();
+
+    for (int t = 1; t <= turns; ++t) {
+        std::cout << "\n--- Turno " << t << " ---\n";
+        worldMap.detectCivilizationBirths();
+        worldMap.ageCivilizations();
+    }
+}
+
+int main() {
+    runSimulation(10);
     return 0;
 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -38,7 +38,24 @@ void Map::detectCivilizationBirths() {
             Cell& cell = grid[y][x];
             if (!cell.hasCivilization && cell.emotion == "Luto" && cell.symbol == "Nome Apagado") {
                 cell.hasCivilization = true;
+                cell.age = 0;
                 std::cout << "Nasce uma civilização em (" << x << "," << y << ")\n";
+            }
+        }
+    }
+}
+
+void Map::ageCivilizations() {
+    for (int y = 0; y < MAP_HEIGHT; ++y) {
+        for (int x = 0; x < MAP_WIDTH; ++x) {
+            Cell& cell = grid[y][x];
+            if (cell.hasCivilization) {
+                cell.age++;
+                if (cell.age > CIV_COLLAPSE_AGE) {
+                    cell.hasCivilization = false;
+                    cell.age = 0;
+                    std::cout << "Civilização colapsa em (" << x << "," << y << ")\n";
+                }
             }
         }
     }

--- a/src/map.hpp
+++ b/src/map.hpp
@@ -7,8 +7,12 @@
 #include <cstdlib>
 #include <ctime>
 
-const int MAP_WIDTH = 10;
+// Dimensões do mapa (colunas x linhas)
+const int MAP_WIDTH = 20;
 const int MAP_HEIGHT = 10;
+
+// Idade limite para colapso de uma civilização
+const int CIV_COLLAPSE_AGE = 5;
 
 extern std::vector<std::string> emotions;
 extern std::vector<std::string> symbols;
@@ -17,6 +21,7 @@ struct Cell {
     std::string emotion;
     std::string symbol;
     bool hasCivilization = false;
+    int age = 0;
 };
 
 class Map {
@@ -28,6 +33,7 @@ public:
     void generateMap();
     void printMap() const;
     void detectCivilizationBirths();
+    void ageCivilizations();
 };
 
 #endif // MAP_HPP


### PR DESCRIPTION
## Summary
- track civilization age inside `Cell`
- add method to age and collapse civilizations
- simulate several turns in an organized `runSimulation` function
- document the new behavior in README
- set map width to 20 to match README

## Testing
- `make clean && make`
- `./EmergenceSim | grep -E "Nasce|colapsa" | head`

------
https://chatgpt.com/codex/tasks/task_e_684823d609688323af775476d669eb15