### PR TITLE
Add simple civilization expansion mechanic

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,6 @@ make
 O programa gera um mapa 20x10 com algumas células contendo símbolos.
 Durante vários turnos, se uma célula tiver o clima "Luto" e o símbolo
 "Nome Apagado", nasce uma nova civilização. Cada civilização envelhece a
-cada turno e colapsa após atingir cinco turnos de idade.
+cada turno e colapsa após atingir cinco turnos de idade. Civilizações com mais
+de dois turnos tentam se expandir para uma célula vizinha vazia, criando uma
+nova colônia.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@ void runSimulation(int turns) {
         std::cout << "\n--- Turno " << t << " ---\n";
         worldMap.detectCivilizationBirths();
         worldMap.ageCivilizations();
+        worldMap.expandCivilizations();
     }
 }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -60,3 +60,28 @@ void Map::ageCivilizations() {
         }
     }
 }
+
+void Map::expandCivilizations() {
+    for (int y = 0; y < MAP_HEIGHT; ++y) {
+        for (int x = 0; x < MAP_WIDTH; ++x) {
+            Cell& cell = grid[y][x];
+            if (cell.hasCivilization && cell.age >= CIV_EXPANSION_AGE) {
+                int dirs[4][2] = {{0,1},{1,0},{0,-1},{-1,0}};
+                // try to find an empty adjacent cell
+                for (auto& d : dirs) {
+                    int nx = x + d[0];
+                    int ny = y + d[1];
+                    if (nx >=0 && nx < MAP_WIDTH && ny >=0 && ny < MAP_HEIGHT) {
+                        Cell& neighbor = grid[ny][nx];
+                        if (!neighbor.hasCivilization) {
+                            neighbor.hasCivilization = true;
+                            neighbor.age = 0;
+                            std::cout << "Civilização se expande para (" << nx << "," << ny << ")\n";
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/map.hpp
+++ b/src/map.hpp
@@ -13,6 +13,8 @@ const int MAP_HEIGHT = 10;
 
 // Idade limite para colapso de uma civilização
 const int CIV_COLLAPSE_AGE = 5;
+// Idade mínima para expansão de uma civilização
+const int CIV_EXPANSION_AGE = 2;
 
 extern std::vector<std::string> emotions;
 extern std::vector<std::string> symbols;
@@ -34,6 +36,7 @@ public:
     void printMap() const;
     void detectCivilizationBirths();
     void ageCivilizations();
+    void expandCivilizations();
 };
 
 #endif // MAP_HPP


### PR DESCRIPTION
## Summary
- add `CIV_EXPANSION_AGE` constant and `expandCivilizations` method
- civilizations older than two turns now expand into neighboring cells
- call expansion step in main simulation loop
- update README with description of expansion mechanic

## Testing
- `make clean && make`
- `./EmergenceSim`

------
https://chatgpt.com/codex/tasks/task_e_684824e053948323b072d94d8e86711b